### PR TITLE
Improve transformations names

### DIFF
--- a/examples/opengl_tutorials/3_camera/main.cpp
+++ b/examples/opengl_tutorials/3_camera/main.cpp
@@ -152,7 +152,7 @@ int main(int argc, char* argv[]) {
   /// Rotation around x axis by M_PI brings our normal computer vision camera
   // (z - forward from the user, x - right, y - down) to the opengl coordinate
   /// system (z - backwards, towards the user, x - right, y - up).
-  const Eigen::Isometry3f tf__gl_camera__camera{
+  const Eigen::Isometry3f tf_gl_camera_from_camera{
       Eigen::AngleAxisf{M_PI, Eigen::Vector3f::UnitX()}};
 
   while (!viewer.ShouldClose()) {
@@ -167,7 +167,8 @@ int main(int argc, char* argv[]) {
     texture_2->Bind();
 
     program->SetUniform(
-        "view", (tf__gl_camera__camera * camera.tf__camera__world()).matrix());
+        "view",
+        (tf_gl_camera_from_camera * camera.tf_camera_from_world()).matrix());
     Eigen::Affine3f model{Eigen::AngleAxisf{0.0f, Eigen::Vector3f::UnitX()}};
     program->SetUniform("model", model.matrix());
 

--- a/gl/core/program.h
+++ b/gl/core/program.h
@@ -29,7 +29,7 @@ class Program : public OpenGlObject {
   template <typename T, typename A>
   inline std::size_t SetUniform(const std::string& uniform_name,
                                 const std::vector<T, A>& data) {
-    auto uniform_index{GetUniformIndexOrEmplace(uniform_name)};
+    const auto uniform_index{GetUniformIndexOrEmplace(uniform_name)};
     uniforms_[uniform_index].UpdateValue(data);
     return uniform_index;
   }
@@ -37,7 +37,7 @@ class Program : public OpenGlObject {
   template <typename... Ts>
   inline std::size_t SetUniform(const std::string& uniform_name,
                                 Ts... numbers) {
-    auto uniform_index{GetUniformIndexOrEmplace(uniform_name)};
+    const auto uniform_index{GetUniformIndexOrEmplace(uniform_name)};
     uniforms_[uniform_index].UpdateValue(numbers...);
     return uniform_index;
   }

--- a/gl/scene/scene_graph.cpp
+++ b/gl/scene/scene_graph.cpp
@@ -39,16 +39,17 @@ SceneGraph::Key SceneGraph::RegisterBranchKey(Key key) {
   return key;
 }
 
-SceneGraph::Key SceneGraph::Attach(Key parent_key,
-                                   Drawable::SharedPtr drawable,
-                                   const Eigen::Isometry3f& tf__parent__local,
-                                   Key new_key) {
+SceneGraph::Key SceneGraph::Attach(
+    Key parent_key,
+    Drawable::SharedPtr drawable,
+    const Eigen::Isometry3f& tf_parent_from_local,
+    Key new_key) {
   std::lock_guard<decltype(graph_mutex)> guard(graph_mutex);
   CHECK_GT(storage_.count(parent_key), 0u) << "New node must have a parent";
   storage_.emplace(
       new_key,
       std::make_unique<Node>(
-          new_key, parent_key, drawable, tf__parent__local, &storage_));
+          new_key, parent_key, drawable, tf_parent_from_local, &storage_));
   storage_.at(parent_key)->AddChildKey(new_key);
   return new_key;
 }
@@ -68,42 +69,45 @@ void SceneGraph::Draw(Key key) {
 SceneGraph::Node::Node(SceneGraph::Key node_key,
                        SceneGraph::Key parent_key,
                        Drawable::SharedPtr drawable,
-                       const Eigen::Isometry3f& tf__parent__local,
+                       const Eigen::Isometry3f& tf_parent_from_local,
                        SceneGraph::Storage<UniquePtr>* storage)
     : key_{node_key},
       parent_key_{parent_key},
-      tf__parent__local_{tf__parent__local},
+      tf_parent_from_local_{tf_parent_from_local},
       drawable_{drawable},
       storage_{storage} {
   CHECK_NOTNULL(storage_);
 }
 
-void SceneGraph::Node::Draw(const Eigen::Isometry3f& tx_accumulated) const {
+void SceneGraph::Node::Draw(
+    const Eigen::Isometry3f& tf_world_from_parent) const {
   CHECK_NOTNULL(storage_);
-  Eigen::Isometry3f tx_world_local = tx_accumulated * tf__parent__local_;
+  Eigen::Isometry3f tf_world_from_local =
+      tf_world_from_parent * tf_parent_from_local_;
   if (drawable_) {
     if (!drawable_->ready_to_draw()) { drawable_->FillBuffers(); }
-    drawable_->SetModel(tx_world_local.matrix());
+    drawable_->SetModel(tf_world_from_local.matrix());
     drawable_->Draw();
   }
   for (const auto& child_key : children_keys_) {
     DCHECK_GT(storage_->count(child_key), 0u);
     const auto& child = storage_->at(child_key);
-    child->Draw(tx_world_local);
+    child->Draw(tf_world_from_local);
   }
 }
 
-Eigen::Isometry3f SceneGraph::Node::ComputeTxAccumulated() const {
+Eigen::Isometry3f SceneGraph::Node::ComputeTfWorldFromLocal() const {
   CHECK_NOTNULL(storage_);
-  Eigen::Isometry3f tx_accumulated = tf__parent__local_;
+  Eigen::Isometry3f tf_current_parent_from_local = tf_parent_from_local_;
   Key parent_key = parent_key_;
   while (parent_key != kRootKey) {
     DCHECK_GT(storage_->count(parent_key), static_cast<size_t>(0));
     auto& parent_node = storage_->at(parent_key);
-    tx_accumulated = parent_node->tf__parent__local() * tx_accumulated;
+    tf_current_parent_from_local =
+        parent_node->tf_parent_from_local() * tf_current_parent_from_local;
     parent_key = parent_node->parent_key();
   }
-  return tx_accumulated;
+  return tf_current_parent_from_local;
 }
 
 SceneGraph::NodeEraser::NodeEraser(

--- a/gl/scene/scene_graph.h
+++ b/gl/scene/scene_graph.h
@@ -43,7 +43,7 @@ class SceneGraph {
   /// child to parent.
   Key Attach(Key parent_key,
              Drawable::SharedPtr drawable,
-             const Eigen::Isometry3f& tf__parent__local =
+             const Eigen::Isometry3f& tf_parent_from_local =
                  Eigen::Isometry3f::Identity(),
              Key new_key = SceneGraph::GenerateNextKey());
 
@@ -76,7 +76,7 @@ class SceneGraph {
     Node(Key node_key,
          Key parent_key,
          Drawable::SharedPtr drawable,
-         const Eigen::Isometry3f& tf__parent__local_,
+         const Eigen::Isometry3f& tf_parent_from_local_,
          SceneGraph::Storage<UniquePtr>* storage);
 
     /// Add a child key to the node.
@@ -87,16 +87,16 @@ class SceneGraph {
     inline void ClearChildKeys() noexcept { children_keys_.clear(); }
 
     /// Draw this node at the correct position in the world.
-    void Draw(const Eigen::Isometry3f& tx_accumulated =
+    void Draw(const Eigen::Isometry3f& tf_world_from_parent =
                   Eigen::Isometry3f::Identity()) const;
-    Eigen::Isometry3f ComputeTxAccumulated() const;
+    Eigen::Isometry3f ComputeTfWorldFromLocal() const;
 
     Key key() const { return key_; }
     Key parent_key() const { return parent_key_; }
 
-    Eigen::Isometry3f& tf__parent__local() { return tf__parent__local_; }
-    const Eigen::Isometry3f& tf__parent__local() const {
-      return tf__parent__local_;
+    Eigen::Isometry3f& tf_parent_from_local() { return tf_parent_from_local_; }
+    const Eigen::Isometry3f& tf_parent_from_local() const {
+      return tf_parent_from_local_;
     }
 
     const std::set<Key>& children_keys() const { return children_keys_; }
@@ -112,7 +112,7 @@ class SceneGraph {
     std::set<Key> children_keys_{};
 
     /// Relative transformation from this coordinate frame to parent's one.
-    Eigen::Isometry3f tf__parent__local_{};
+    Eigen::Isometry3f tf_parent_from_local_{};
 
     /// Every node is storing a drawable.
     Drawable::SharedPtr drawable_{};

--- a/gl/scene/scene_graph_test.cpp
+++ b/gl/scene/scene_graph_test.cpp
@@ -82,12 +82,12 @@ TEST_F(SceneGraphTest, Transform) {
   test_transform.translation() = Eigen::Vector3f{1, 1, 1};
   auto key_2 = graph.Attach(world_key, other_drawable, test_transform);
   EXPECT_EQ(graph.size(), 3u);
-  EXPECT_EQ(graph.GetNode(key_1).tf__parent__local().translation().x(), 0);
-  EXPECT_EQ(graph.GetNode(key_1).tf__parent__local().translation().y(), 0);
-  EXPECT_EQ(graph.GetNode(key_1).tf__parent__local().translation().z(), 0);
-  EXPECT_EQ(graph.GetNode(key_2).tf__parent__local().translation().x(), 1);
-  EXPECT_EQ(graph.GetNode(key_2).tf__parent__local().translation().y(), 1);
-  EXPECT_EQ(graph.GetNode(key_2).tf__parent__local().translation().z(), 1);
+  EXPECT_EQ(graph.GetNode(key_1).tf_parent_from_local().translation().x(), 0);
+  EXPECT_EQ(graph.GetNode(key_1).tf_parent_from_local().translation().y(), 0);
+  EXPECT_EQ(graph.GetNode(key_1).tf_parent_from_local().translation().z(), 0);
+  EXPECT_EQ(graph.GetNode(key_2).tf_parent_from_local().translation().x(), 1);
+  EXPECT_EQ(graph.GetNode(key_2).tf_parent_from_local().translation().y(), 1);
+  EXPECT_EQ(graph.GetNode(key_2).tf_parent_from_local().translation().z(), 1);
 }
 
 TEST_F(SceneGraphTest, ChainTransform) {
@@ -98,15 +98,18 @@ TEST_F(SceneGraphTest, ChainTransform) {
   auto key_1 = graph.Attach(world_key, default_drawable_, test_transform);
   auto key_2 = graph.Attach(key_1, default_drawable_, test_transform);
   EXPECT_EQ(graph.size(), 3u);
-  EXPECT_EQ(graph.GetNode(key_1).tf__parent__local().translation().x(), 1);
-  EXPECT_EQ(graph.GetNode(key_1).tf__parent__local().translation().y(), 1);
-  EXPECT_EQ(graph.GetNode(key_1).tf__parent__local().translation().z(), 1);
-  EXPECT_EQ(graph.GetNode(key_2).tf__parent__local().translation().x(), 1);
-  EXPECT_EQ(graph.GetNode(key_2).tf__parent__local().translation().y(), 1);
-  EXPECT_EQ(graph.GetNode(key_2).tf__parent__local().translation().z(), 1);
-  EXPECT_EQ(graph.GetNode(key_2).ComputeTxAccumulated().translation().x(), 2);
-  EXPECT_EQ(graph.GetNode(key_2).ComputeTxAccumulated().translation().y(), 2);
-  EXPECT_EQ(graph.GetNode(key_2).ComputeTxAccumulated().translation().z(), 2);
+  EXPECT_EQ(graph.GetNode(key_1).tf_parent_from_local().translation().x(), 1);
+  EXPECT_EQ(graph.GetNode(key_1).tf_parent_from_local().translation().y(), 1);
+  EXPECT_EQ(graph.GetNode(key_1).tf_parent_from_local().translation().z(), 1);
+  EXPECT_EQ(graph.GetNode(key_2).tf_parent_from_local().translation().x(), 1);
+  EXPECT_EQ(graph.GetNode(key_2).tf_parent_from_local().translation().y(), 1);
+  EXPECT_EQ(graph.GetNode(key_2).tf_parent_from_local().translation().z(), 1);
+  EXPECT_EQ(graph.GetNode(key_2).ComputeTfWorldFromLocal().translation().x(),
+            2);
+  EXPECT_EQ(graph.GetNode(key_2).ComputeTfWorldFromLocal().translation().y(),
+            2);
+  EXPECT_EQ(graph.GetNode(key_2).ComputeTfWorldFromLocal().translation().z(),
+            2);
 }
 
 TEST_F(SceneGraphTest, SimpleErase) {

--- a/gl/utils/camera_test.cpp
+++ b/gl/utils/camera_test.cpp
@@ -6,13 +6,14 @@ using namespace gl;
 TEST(CameraTest, Posititon) {
   const float radius{5.0f};
   Camera camera{radius};
-  Eigen::Matrix4f tf__camera__world;
-  tf__camera__world << 0, 1, 0, 0,  //
-      0, 0, -1, 0,                  //
-      -1, 0, 0, 5,                  //
+  Eigen::Matrix4f tf_camera_from_world;
+  tf_camera_from_world << 0, 1, 0, 0,  //
+      0, 0, -1, 0,                     //
+      -1, 0, 0, 5,                     //
       0, 0, 0, 1;
-  EXPECT_TRUE(camera.tf__camera__world().matrix().isApprox(tf__camera__world))
-      << camera.tf__camera__world().matrix();
+  EXPECT_TRUE(
+      camera.tf_camera_from_world().matrix().isApprox(tf_camera_from_world))
+      << camera.tf_camera_from_world().matrix();
   const Eigen::Vector3f position{1, 2, 3};
   camera.SetTargetPosition(position);
   EXPECT_TRUE(camera.GetTargetPosition().isApprox(position));
@@ -25,7 +26,7 @@ TEST(CameraTest, CameraFromWorld) {
                   const Eigen::Vector4f& world_point,
                   const Eigen::Vector4f& expected_camera_point) {
     const Eigen::Vector4f camera_point =
-        camera.tf__camera__world() * world_point;
+        camera.tf_camera_from_world() * world_point;
     EXPECT_TRUE(camera_point.isApprox(expected_camera_point))
         << "Actual: " << camera_point.transpose()
         << "\nExpected: " << expected_camera_point.transpose();
@@ -37,14 +38,15 @@ TEST(CameraTest, CameraFromWorld) {
   target_position = {0, 0, 0};
   camera.LookAt(target_position, camera_position);
   EXPECT_TRUE(camera.GetTargetPosition().isApprox(target_position))
-      << camera.tf__camera__world().matrix();
+      << camera.tf_camera_from_world().matrix();
   Check(camera, {0, 0, 0, 1}, {0, 0, 1, 1});
   camera_position = {2, 2, 2};
   camera.LookAt(target_position, camera_position);
   EXPECT_TRUE(camera.GetTargetPosition().isApprox(target_position))
-      << camera.tf__camera__world().matrix();
-  EXPECT_TRUE((camera.tf__world__camera() * Eigen::Vector3f{0.0f, 0.0f, 0.0f})
-                  .isApprox(camera_position))
-      << camera.tf__world__camera().matrix();
+      << camera.tf_camera_from_world().matrix();
+  EXPECT_TRUE(
+      (camera.tf_world_from_camera() * Eigen::Vector3f{0.0f, 0.0f, 0.0f})
+          .isApprox(camera_position))
+      << camera.tf_world_from_camera().matrix();
   Check(camera, {1, 1, 1, 1}, {0, 0, sqrt(3), 1});
 }

--- a/gl/viewer/viewer.cpp
+++ b/gl/viewer/viewer.cpp
@@ -130,7 +130,8 @@ void SceneViewer::OnKeyboardEvent(const std::set<gl::core::KeyboardKey>& keys) {
 
 void SceneViewer::UpdateCameraNodePosition() {
   CHECK(graph_.HasNode(camera_key_));
-  graph_.GetNode(camera_key_).tf__parent__local() = camera_.tf__world__target();
+  graph_.GetNode(camera_key_).tf_parent_from_local() =
+      camera_.tf_world_from_target();
 }
 
 }  // namespace gl

--- a/gl/viewer/viewer.h
+++ b/gl/viewer/viewer.h
@@ -30,11 +30,12 @@ class SceneViewer {
   }
 
   /// Attach a new drawable to a node in the scene graph.
-  inline gl::SceneGraph::Key Attach(gl::SceneGraph::Key parent_key,
-                                    gl::Drawable::SharedPtr drawable,
-                                    const Eigen::Isometry3f& tx_parent_child =
-                                        Eigen::Isometry3f::Identity()) {
-    auto new_key = graph_.Attach(parent_key, drawable, tx_parent_child);
+  inline gl::SceneGraph::Key Attach(
+      gl::SceneGraph::Key parent_key,
+      gl::Drawable::SharedPtr drawable,
+      const Eigen::Isometry3f& tf_parent_from_local =
+          Eigen::Isometry3f::Identity()) {
+    auto new_key = graph_.Attach(parent_key, drawable, tf_parent_from_local);
     return new_key;
   }
 

--- a/opengl_tutorial.sublime-project
+++ b/opengl_tutorial.sublime-project
@@ -25,6 +25,7 @@
 		[
 			"*gcc*"
 		],
+		"ecc_verbose": true,
 		"ecc_lang_flags":
 		{
 			"C":


### PR DESCRIPTION
Before different transformation matrices were named differently, here we adopt a consistent naming style `tf_<frame_target>_from_<frame_source>`. So if a transformation matrix applies a transform to a point in frame `foo` so that the point becomes a point in frame `bar`, in the code such a matrix would be represented by a variable `tf_bar_from_foo`. 