### PR TITLE
Make programs detect that they are used

### DIFF
--- a/examples/3d_viewer/main.cpp
+++ b/examples/3d_viewer/main.cpp
@@ -10,21 +10,52 @@
 #include <ostream>
 #include <vector>
 
+namespace {
+
 using namespace units::literals;
+using gl::Shader;
 using utils::Image;
+
+}  // namespace
 
 int main(int argc, char* argv[]) {
   gl::SceneViewer viewer{"3D Scene Viewer"};
   viewer.Initialize();
 
+  auto& program_pool = viewer.program_pool();
+
+  const auto draw_points_program_index =
+      program_pool.AddProgramFromShaders(Shader::CreateFromFiles(
+          {"gl/scene/shaders/points.vert", "gl/scene/shaders/simple.frag"}));
+  CHECK(draw_points_program_index.has_value());
+  const auto draw_coordinate_system_program_index =
+      program_pool.AddProgramFromShaders(
+          Shader::CreateFromFiles({"gl/scene/shaders/coordinate_system.vert",
+                                   "gl/scene/shaders/coordinate_system.geom",
+                                   "gl/scene/shaders/simple.frag"}));
+  CHECK(draw_coordinate_system_program_index.has_value());
+  const auto draw_textured_rect_program_index =
+      program_pool.AddProgramFromShaders(
+          Shader::CreateFromFiles({"gl/scene/shaders/texture.vert",
+                                   "gl/scene/shaders/texture.geom",
+                                   "gl/scene/shaders/texture.frag"}));
+  CHECK(draw_textured_rect_program_index.has_value());
+  const auto draw_text_program_index =
+      program_pool.AddProgramFromShaders(Shader::CreateFromFiles(
+          {"gl/scene/shaders/text.vert", "gl/scene/shaders/texture.frag"}));
+  CHECK(draw_text_program_index.has_value());
+
   auto cloud_ptr =
       PointCloud::FromFile("examples/3d_viewer/utils/test_data/cloud.txt");
 
-  auto points_drawable = std::make_shared<gl::Points>(
-      viewer.program_pool(), cloud_ptr->points(), cloud_ptr->intensities());
+  auto points_drawable =
+      std::make_shared<gl::Points>(&viewer.program_pool(),
+                                   draw_points_program_index.value(),
+                                   cloud_ptr->points(),
+                                   cloud_ptr->intensities());
 
-  auto camera_center_drawable =
-      std::make_shared<gl::CoordinateSystem>(viewer.program_pool());
+  auto camera_center_drawable = std::make_shared<gl::CoordinateSystem>(
+      &viewer.program_pool(), draw_coordinate_system_program_index.value());
 
   viewer.Attach(viewer.world_key(), points_drawable);
   viewer.Attach(viewer.camera_key(), camera_center_drawable);

--- a/examples/opengl_tutorials/1_hello_triangle/main.cpp
+++ b/examples/opengl_tutorials/1_hello_triangle/main.cpp
@@ -43,14 +43,12 @@ int main(int argc, char* argv[]) {
       "opengl_tutorials/1_hello_triangle/shaders/triangle.frag")};
   if (!vertex_shader || !fragment_shader) { exit(EXIT_FAILURE); }
 
-  const auto program =
+  auto program =
       gl::Program::CreateFromShaders({vertex_shader, fragment_shader});
   if (!program) {
     std::cerr << "Failed to link program" << std::endl;
     return EXIT_FAILURE;
   }
-
-  auto* color_uniform = program->EmplaceUniform({"ourColor", program->id()});
 
   gl::VertexArrayBuffer vertex_array_buffer{};
   vertex_array_buffer.AssignBuffer(
@@ -78,7 +76,7 @@ int main(int argc, char* argv[]) {
 
     program->Use();
     float green_value = (sin(viewer.GetTime() * 3.0f) / 2.0f) + 0.5f;
-    color_uniform->UpdateValue(0.0f, green_value, 0.0f);
+    (void)program->SetUniform("ourColor", 0.0f, green_value, 0.0f);
 
     vertex_array_buffer.Draw(GL_TRIANGLES);
     viewer.Spin();

--- a/examples/opengl_tutorials/2_textures/main.cpp
+++ b/examples/opengl_tutorials/2_textures/main.cpp
@@ -78,20 +78,20 @@ int main(int argc, char* argv[]) {
   CHECK(vertex_shader) << "Could not create vertex shader.";
   CHECK(fragment_shader) << "Could not create fragment shader.";
 
-  const auto program =
+  auto program =
       gl::Program::CreateFromShaders({vertex_shader, fragment_shader});
   CHECK(program) << "Failed to link program.";
 
   program->Use();
-  program->SetUniform("texture1", 0);
-  program->SetUniform("texture2", 1);
+  (void)program->SetUniform("texture1", 0);
+  (void)program->SetUniform("texture2", 1);
 
   float mixture = 0.0f;
-  program->SetUniform("mix_ratio", mixture);
+  (void)program->SetUniform("mix_ratio", mixture);
 
   Eigen::Affine3f transform{
       Eigen::AngleAxisf{mixture, Eigen::Vector3f::UnitZ()}};
-  program->SetUniform("transform", transform.matrix());
+  (void)program->SetUniform("transform", transform.matrix());
 
   gl::VertexArrayBuffer vertex_array_buffer{};
   vertex_array_buffer.EnableVertexAttributePointer(
@@ -123,8 +123,8 @@ int main(int argc, char* argv[]) {
     }
     Eigen::Affine3f transform{
         Eigen::AngleAxisf{mixture, Eigen::Vector3f{0, 0, 1}}};
-    program->SetUniform("transform", transform.matrix());
-    program->SetUniform("mix_ratio", mixture);
+    (void)program->SetUniform("transform", transform.matrix());
+    (void)program->SetUniform("mix_ratio", mixture);
   };
 
   viewer.user_input_handler().RegisterKeyboardCallback(on_key_press);

--- a/examples/opengl_tutorials/3_camera/main.cpp
+++ b/examples/opengl_tutorials/3_camera/main.cpp
@@ -85,24 +85,24 @@ int main(int argc, char* argv[]) {
       "examples/opengl_tutorials/3_camera/shaders/triangle.frag")};
   if (!vertex_shader || !fragment_shader) { exit(EXIT_FAILURE); }
 
-  const auto program =
+  auto program =
       gl::Program::CreateFromShaders({vertex_shader, fragment_shader});
   if (!program) {
     std::cerr << "Failed to link program" << std::endl;
     return EXIT_FAILURE;
   }
   program->Use();
-  program->SetUniform("texture1", 0);
-  program->SetUniform("texture2", 1);
+  (void)program->SetUniform("texture1", 0);
+  (void)program->SetUniform("texture2", 1);
 
   float mixture = 0.5f;
-  program->SetUniform("mix_ratio", mixture);
+  (void)program->SetUniform("mix_ratio", mixture);
 
   gl::Camera camera{};
 
   Eigen::Matrix4f perspective = camera.Perspective(
       45_deg, viewer.window_size().width, viewer.window_size().height);
-  program->SetUniform("projection", perspective);
+  (void)program->SetUniform("projection", perspective);
 
   gl::VertexArrayBuffer vertex_array_buffer{};
   vertex_array_buffer.EnableVertexAttributePointer(
@@ -166,11 +166,11 @@ int main(int argc, char* argv[]) {
     texture_1->Bind();
     texture_2->Bind();
 
-    program->SetUniform(
+    (void)program->SetUniform(
         "view",
         (tf_gl_camera_from_camera * camera.tf_camera_from_world()).matrix());
     Eigen::Affine3f model{Eigen::AngleAxisf{0.0f, Eigen::Vector3f::UnitX()}};
-    program->SetUniform("model", model.matrix());
+    (void)program->SetUniform("model", model.matrix());
 
     vertex_array_buffer.Draw(GL_TRIANGLES);
     viewer.Spin();

--- a/gl/core/buffer.h
+++ b/gl/core/buffer.h
@@ -10,6 +10,7 @@
 
 namespace gl {
 
+// TODO(igor): probably replace the globject with traits.
 class Buffer : public OpenGlObject {
  public:
   enum class Type : GLenum {
@@ -23,9 +24,7 @@ class Buffer : public OpenGlObject {
   };
 
   Buffer(Buffer::Type type, Buffer::Usage usage)
-      : OpenGlObject{0},
-        type_{static_cast<GLenum>(type)},
-        usage_{static_cast<GLenum>(usage)} {
+      : type_{static_cast<GLenum>(type)}, usage_{static_cast<GLenum>(usage)} {
     glGenBuffers(1, &id_);
   }
 
@@ -64,7 +63,7 @@ class Buffer : public OpenGlObject {
   }
 
   ~Buffer() {
-    if (id_ < 1u) { return; }
+    if (!id_) { return; }
     // If the id is valid, then we have things to unbind.
     UnBind();
     glDeleteBuffers(1, &id_);

--- a/gl/core/program.cpp
+++ b/gl/core/program.cpp
@@ -20,11 +20,11 @@ Uniform* Program::EmplaceUniform(Uniform&& uniform) {
   return &uniforms_.emplace_back(std::forward<Uniform>(uniform));
 }
 
-std::unique_ptr<Program> Program::CreateFromShaders(
+std::optional<Program> Program::CreateFromShaders(
     const std::vector<std::shared_ptr<Shader>>& shaders) {
-  auto program{std::make_unique<Program>()};
-  program->AttachShaders(shaders);
-  if (!program->Link()) { return nullptr; }
+  Program program;
+  program.AttachShaders(shaders);
+  if (!program.Link()) { return {}; }
   return program;
 }
 

--- a/gl/core/program_test.cpp
+++ b/gl/core/program_test.cpp
@@ -10,7 +10,6 @@ TEST(ProgramTest, Init) {
   const std::shared_ptr<Shader> fragment_shader{
       Shader::CreateFromFile("gl/core/test_shaders/shader.frag")};
   ASSERT_NE(fragment_shader, nullptr);
-  const auto program{
-      Program::CreateFromShaders({vertex_shader, fragment_shader})};
-  ASSERT_NE(program, nullptr);
+  auto program{Program::CreateFromShaders({vertex_shader, fragment_shader})};
+  ASSERT_TRUE(program.has_value());
 }

--- a/gl/core/shader.h
+++ b/gl/core/shader.h
@@ -6,6 +6,7 @@
 #include "gl/core/opengl_object.h"
 #include "glog/logging.h"
 
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -26,7 +27,12 @@ class Shader : public OpenGlObject {
   Shader(Shader&& other) = delete;
   Shader& operator=(Shader&& other) = delete;
 
-  static std::unique_ptr<Shader> CreateFromFile(const std::string& file_name);
+  static std::unique_ptr<Shader> CreateFromFile(
+      const std::filesystem::path& file_name);
+
+  static std::vector<std::shared_ptr<Shader>> CreateFromFiles(
+      const std::vector<std::filesystem::path>& file_names);
+
   inline Shader::Type type() const { return type_; }
 
   ~Shader() { glDeleteShader(id_); }

--- a/gl/core/shader_test.cpp
+++ b/gl/core/shader_test.cpp
@@ -1,7 +1,7 @@
 #include "gl/core/shader.h"
 #include "gtest/gtest.h"
 
-using namespace gl;
+using gl::Shader;
 
 TEST(ShaderTest, Init) {
   auto shader{Shader::CreateFromFile("gl/core/test_shaders/shader.vert")};
@@ -14,9 +14,9 @@ TEST(ShaderTest, Init) {
   EXPECT_TRUE(success);
 }
 
-TEST(ShaderTest, InitWrongPath) {
-  const auto shader{Shader::CreateFromFile("wrong/path.vert")};
-  ASSERT_EQ(shader, nullptr);
+TEST(ShaderDeathTest, InitWrongPath) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH(Shader::CreateFromFile("wrong/path.vert"), ".*does not exist.");
 }
 
 TEST(ShaderDeathTest, InitWrongSource) {

--- a/gl/core/uniform_test.cpp
+++ b/gl/core/uniform_test.cpp
@@ -17,14 +17,14 @@ class UniformTest : public ::testing::Test {
         Shader::CreateFromFile("gl/core/test_shaders/shader.frag")};
     ASSERT_NE(fragment_shader, nullptr);
     program_ = Program::CreateFromShaders({vertex_shader, fragment_shader});
-    ASSERT_NE(program_, nullptr);
+    ASSERT_TRUE(program_.has_value());
     int success{};
     glGetProgramiv(program_->id(), GL_LINK_STATUS, &success);
     ASSERT_TRUE(success);
     program_->Use();
   }
 
-  std::shared_ptr<Program> program_{};
+  std::optional<Program> program_{};
 };
 
 TEST_F(UniformTest, Init) {

--- a/gl/scene/drawables/all.h
+++ b/gl/scene/drawables/all.h
@@ -15,12 +15,14 @@ namespace gl {
 /// A class that is responsible for drawing points.
 class Points : public Drawable {
  public:
-  explicit Points(const ProgramPool& program_pool,
+  explicit Points(ProgramPool* program_pool,
+                  ProgramPool::ProgramIndex program_index,
                   const eigen::vector<Eigen::Vector3f>& points,
                   const Eigen::Vector3f& color = {1.0f, 1.0f, 1.0f},
                   float point_size = 3.0f,
                   GLenum gl_mode = GL_POINTS);
-  explicit Points(const ProgramPool& program_pool,
+  explicit Points(ProgramPool* program_pool,
+                  ProgramPool::ProgramIndex program_index,
                   const eigen::vector<Eigen::Vector3f>& points,
                   const std::vector<float>& intensities,
                   const Eigen::Vector3f& color = {1.0f, 1.0f, 1.0f},
@@ -37,7 +39,8 @@ class Points : public Drawable {
 class Lines : public Points {
  public:
   /// Draw lines between non-intersecting sequential pairs of points.
-  explicit Lines(const ProgramPool& program_pool,
+  explicit Lines(ProgramPool* program_pool,
+                 ProgramPool::ProgramIndex program_index,
                  const eigen::vector<Eigen::Vector3f>& points,
                  const Eigen::Vector3f& color = {1.0f, 1.0f, 1.0f},
                  float line_width = 2.0f);
@@ -46,7 +49,8 @@ class Lines : public Points {
 /// Draw a coordinate system.
 class CoordinateSystem : public Drawable {
  public:
-  CoordinateSystem(const ProgramPool& program_pool);
+  CoordinateSystem(ProgramPool* program_pool,
+                   ProgramPool::ProgramIndex program_index);
   void FillBuffers() override;
 };
 

--- a/gl/scene/drawables/drawable.cpp
+++ b/gl/scene/drawables/drawable.cpp
@@ -13,13 +13,14 @@ ABSL_FLAG(float, drawable_point_size, 3.0f, "Default size of the points.");
 
 namespace gl {
 
-Drawable::Drawable(const ProgramPool& program_pool,
-                   const ProgramPool::ProgramType& program_type,
+Drawable::Drawable(ProgramPool* program_pool,
+                   ProgramPool::ProgramIndex program_index,
                    Style style,
                    GLenum mode,
                    float point_size,
                    const Eigen::Vector3f& color)
-    : program_{program_pool.GetProgram(program_type)},
+    : program_pool_{program_pool},
+      program_index_{program_index},
       draw_style_{style},
       mode_{mode},
       point_size_{point_size},
@@ -27,11 +28,12 @@ Drawable::Drawable(const ProgramPool& program_pool,
 
 void Drawable::Draw() {
   CHECK(vao_) << "Need a VAO to draw.";
-  CHECK(program_) << "Need a Program to draw.";
+  CHECK(program_pool_) << "Need a program pool to draw.";
+  CHECK(program_index_) << "Need a program index to draw.";
 
-  program_->Use();
+  program_pool_->UseProgram(program_index_.value());
   if (color_uniform_index_) {
-    program_->GetUniform(color_uniform_index_).UpdateValue(color_);
+    program_pool_->UpdateUniformInActiveProgram(color_uniform_index_, color_);
   }
 
   if (texture_) { texture_->Bind(); }

--- a/gl/scene/program_pool_test.cpp
+++ b/gl/scene/program_pool_test.cpp
@@ -5,16 +5,21 @@
 #include "gl/scene/program_pool.h"
 #include "gtest/gtest.h"
 
-using namespace gl;
+using gl::ProgramPool;
+using gl::Shader;
 
 TEST(ProgramPoolTest, Simple) {
   ProgramPool pool{};
-  const auto& program{pool.AddProgramFromShaders(
-      ProgramPool::ProgramType::DRAW_POINTS,
-      {"gl/scene/shaders/points.vert", "gl/scene/shaders/simple.frag"})};
-  ASSERT_NE(program.get(), nullptr);
-  const auto& same_program{
-      pool.GetProgram(ProgramPool::ProgramType::DRAW_POINTS)};
-  ASSERT_EQ(program.get(), same_program.get());
-  pool.Clear();
+  const auto points_program_index{
+      pool.AddProgramFromShaders(Shader::CreateFromFiles(
+          {"gl/scene/shaders/points.vert", "gl/scene/shaders/simple.frag"}))};
+  ASSERT_TRUE(points_program_index.has_value());
+  ASSERT_EQ(points_program_index.value(), 0UL);
+  const auto another_points_program_index{
+      pool.AddProgramFromShaders(Shader::CreateFromFiles(
+          {"gl/scene/shaders/points.vert", "gl/scene/shaders/simple.frag"}))};
+  ASSERT_TRUE(another_points_program_index.has_value());
+  ASSERT_EQ(another_points_program_index.value(), 1UL);
 }
+
+// TODO(igor): add more tests here

--- a/gl/viewer/viewer.cpp
+++ b/gl/viewer/viewer.cpp
@@ -14,31 +14,6 @@ namespace gl {
 void SceneViewer::Initialize(const glfw::WindowSize& window_size,
                              const glfw::GlVersion& gl_version) {
   CHECK(viewer_.Initialize(window_size, gl_version));
-  viewer_.user_input_handler().RegisterMouseCallback(
-      std::bind(&SceneViewer::OnMouseEvent,
-                this,
-                std::placeholders::_1,
-                std::placeholders::_2,
-                std::placeholders::_3));
-  viewer_.user_input_handler().RegisterKeyboardCallback(
-      std::bind(&SceneViewer::OnKeyboardEvent, this, std::placeholders::_1));
-  program_pool_.AddProgramFromShaders(
-      ProgramPool::ProgramType::DRAW_POINTS,
-      {"gl/scene/shaders/points.vert", "gl/scene/shaders/simple.frag"});
-  program_pool_.AddProgramFromShaders(
-      ProgramPool::ProgramType::DRAW_COORDINATE_SYSTEM,
-      {"gl/scene/shaders/coordinate_system.vert",
-       "gl/scene/shaders/coordinate_system.geom",
-       "gl/scene/shaders/simple.frag"});
-  program_pool_.AddProgramFromShaders(
-      ProgramPool::ProgramType::DRAW_TEXTURED_RECT,
-      {"gl/scene/shaders/texture.vert",
-       "gl/scene/shaders/texture.geom",
-       "gl/scene/shaders/texture.frag"});
-  program_pool_.AddProgramFromShaders(
-      ProgramPool::ProgramType::DRAW_TEXT,
-      {"gl/scene/shaders/text.vert", "gl/scene/shaders/texture.frag"});
-  program_pool_.SetUniformToAllPrograms("proj_view", camera_.TfViewportWorld());
   FontPool::Instance().LoadFont("gl/scene/fonts/ubuntu.fnt");
   opengl_initialized_ = true;
 
@@ -64,6 +39,14 @@ void SceneViewer::EraseScheduledKeys() {
 }
 
 void SceneViewer::Spin() {
+  viewer_.user_input_handler().RegisterMouseCallback(
+      std::bind(&SceneViewer::OnMouseEvent,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2,
+                std::placeholders::_3));
+  viewer_.user_input_handler().RegisterKeyboardCallback(
+      std::bind(&SceneViewer::OnKeyboardEvent, this, std::placeholders::_1));
   while (!viewer_.ShouldClose()) {
     viewer_.ProcessInput();
     EraseScheduledKeys();

--- a/gl/viewer/viewer.h
+++ b/gl/viewer/viewer.h
@@ -56,8 +56,18 @@ class SceneViewer {
   void Spin();
 
   const ProgramPool& program_pool() const noexcept { return program_pool_; }
+  ProgramPool& program_pool() noexcept { return program_pool_; }
 
  protected:
+  void Paint();
+
+  /// Update the current position of the camera node from the current position
+  /// of the camera to correctly draw all the nodes attached to it.
+  void UpdateCameraNodePosition();
+
+  /// Called from gui thread, this actually erases drawables from the graph.
+  void EraseScheduledKeys();
+
   /// The underlying viewer.
   glfw::Viewer viewer_;
 
@@ -70,16 +80,8 @@ class SceneViewer {
   /// initialized before using any functionality from it.
   bool opengl_initialized_;
 
+  /// Detect if shift is pressed.
   bool shift_pressed_{};
-
-  void Paint();
-
-  /// Update the current position of the camera node from the current position
-  /// of the camera to correctly draw all the nodes attached to it.
-  void UpdateCameraNodePosition();
-
-  /// Called from gui thread, this actually erases drawables from the graph.
-  void EraseScheduledKeys();
 
   /// An instance of the camera that we are using here.
   gl::Camera camera_;


### PR DESCRIPTION
This required quite some changes to the code:
- The programs are now movable
- The program pool owns the programs
- The program pool creates program handles upon program addition
- These handles are then propagated to drawables
- Drawables use the program pool internally to operate
- The program pool knows which program is active
- It is now impossible to set a uniform to anon-active program